### PR TITLE
FAT2-326 sitemap

### DIFF
--- a/src/SFA.DAS.FAT.Web.UnitTests/Controllers/HomeControllerTests/WhenGettingTheSitemap.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Controllers/HomeControllerTests/WhenGettingTheSitemap.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.FAT.Application.Courses.Queries.GetCourses;
+using SFA.DAS.FAT.Domain.Courses;
+using SFA.DAS.FAT.Web.Controllers;
+using SFA.DAS.FAT.Web.Infrastructure;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.FAT.Web.UnitTests.Controllers.HomeControllerTests
+{
+    public class WhenGettingTheSitemap
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Routes_Are_Added(
+            string serviceStartUrl,
+            string shortlistUrl,
+            string privacyUrl,
+            string accessibilityUrl,
+            string cookiesUrl,
+            string cookiesDetailsUrl,
+            string coursesUrl,
+            GetCoursesResult result,
+            [Frozen] Mock<IMediator> mediator)
+        {
+            var httpContext = new DefaultHttpContext();
+            var urlHelper = new Mock<IUrlHelper>();
+            
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.ServiceStart))))
+                .Returns(serviceStartUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.Courses))))
+                .Returns(coursesUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.ShortList))))
+                .Returns(shortlistUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.Privacy))))
+                .Returns(privacyUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.AccessibilityStatement))))
+                .Returns(accessibilityUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.Cookies))))
+                .Returns(cookiesUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.CookiesDetails))))
+                .Returns(cookiesDetailsUrl);
+            mediator.Setup(x => x.Send(It.Is<GetCoursesQuery>(c => 
+                    c.Keyword.Equals("")
+                    && c.Levels == null
+                    && c.RouteIds == null
+                    && c.ShortlistUserId == null
+                    && c.OrderBy.Equals(OrderBy.Name)
+                ), CancellationToken.None))
+                .ReturnsAsync(result);
+            var controller = new HomeController(mediator.Object) {
+                Url = urlHelper.Object, 
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = httpContext
+                }
+            };
+            
+            //Act
+            var actual = await controller.SitemapXml() as ContentResult;
+            
+            //Assert
+            Assert.IsNotNull(actual);
+            var document = new XmlDocument();
+            document.LoadXml(actual.Content);
+            
+            var newNode  = XDocument.Parse(actual.Content).Root;
+            Assert.IsNotNull(newNode);
+            var nodes = newNode.Descendants(newNode.GetDefaultNamespace()+"loc").ToList();
+            nodes.Any(c => c.Value.Equals(serviceStartUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(coursesUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(shortlistUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(privacyUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(accessibilityUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(cookiesUrl)).Should().BeTrue();
+            nodes.Any(c => c.Value.Equals(cookiesDetailsUrl)).Should().BeTrue();
+        }
+        
+        [Test, MoqAutoData]
+        public async Task Then_The_Courses_Query_Is_Called_And_Nodes_Built_For_Each_Course_And_Provider_List(
+            string courseUrl,
+            string courseProvidersUrl,
+            GetCoursesResult result,
+            [Frozen] Mock<IMediator> mediator)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            var urlHelper = new Mock<IUrlHelper>();
+            
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.CourseDetails))))
+                .Returns(courseUrl);
+            urlHelper
+                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.CourseProviders))))
+                .Returns(courseProvidersUrl);
+
+            var controller = new HomeController(mediator.Object) {
+                Url = urlHelper.Object, 
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = httpContext
+                }
+            };
+            mediator.Setup(x => x.Send(It.Is<GetCoursesQuery>(c => 
+                    c.Keyword.Equals("")
+                    && c.Levels == null
+                    && c.RouteIds == null
+                    && c.ShortlistUserId == null
+                    && c.OrderBy.Equals(OrderBy.Name)
+                    ), CancellationToken.None))
+                .ReturnsAsync(result);
+            
+            //Act
+            var actual = await controller.SitemapXml() as ContentResult;
+            
+            //Assert
+            Assert.IsNotNull(actual);
+            var document = new XmlDocument();
+            document.LoadXml(actual.Content);
+            
+            var newNode  = XDocument.Parse(actual.Content).Root;
+            Assert.IsNotNull(newNode);
+            var nodes = newNode.Descendants(newNode.GetDefaultNamespace()+"loc").ToList();
+
+            nodes.Count(c => c.Value.Equals(courseUrl)).Should().Be(result.Courses.Count);
+            nodes.Count(c => c.Value.Equals(courseProvidersUrl)).Should().Be(result.Courses.Count);
+            
+        }
+    }
+}

--- a/src/SFA.DAS.FAT.Web/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.FAT.Web/AppStart/AddServiceRegistrationExtension.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.FAT.Web.AppStart
     {
         public static void AddServiceRegistration(this IServiceCollection services)
         {
+            services.AddDistributedMemoryCache();
             services.AddHttpClient<IApiClient, ApiClient>();
             services.AddTransient<ICourseService, CourseService>();
             services.AddTransient<ILocationService, LocationService>();

--- a/src/SFA.DAS.FAT.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/HomeController.cs
@@ -1,10 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.FAT.Application.Courses.Queries.GetCourses;
+using SFA.DAS.FAT.Domain.Courses;
 using SFA.DAS.FAT.Web.Infrastructure;
 
 namespace SFA.DAS.FAT.Web.Controllers
 {
     public class HomeController : Controller
     {
+        private readonly IMediator _mediator;
+
+        public HomeController (IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+        
         [Route("", Name = RouteNames.ServiceStartDefault, Order = 0)]
         [Route("start", Name = RouteNames.ServiceStart, Order = 1)]
         public IActionResult Index()
@@ -22,6 +38,60 @@ namespace SFA.DAS.FAT.Web.Controllers
         public IActionResult CookiesDetails()
         {
             return View();
+        }
+
+        [Route("sitemap.xml")]
+        public async Task<IActionResult> SitemapXml()
+        {
+            var result = await _mediator.Send(new GetCoursesQuery
+            {
+                Keyword = "",
+                RouteIds = null,
+                Levels = null,
+                OrderBy = OrderBy.Name,
+                ShortlistUserId = null
+            });
+            
+            var urlList = new List<string>
+            {
+                Url.RouteUrl(RouteNames.ServiceStart,null,Request.Scheme, Request.Host.Host),
+                Url.RouteUrl(RouteNames.Courses,null,Request.Scheme, Request.Host.Host),
+            
+            };
+            urlList.AddRange(result.Courses.Select(course => Url.RouteUrl(RouteNames.CourseDetails, new {course.Id}, Request.Scheme, Request.Host.Host)));
+            urlList.AddRange(result.Courses.Select(course => Url.RouteUrl(RouteNames.CourseProviders, new {course.Id}, Request.Scheme, Request.Host.Host)));
+
+            urlList.Add(Url.RouteUrl(RouteNames.ShortList, null, Request.Scheme, Request.Host.Host));
+            urlList.Add(Url.RouteUrl(RouteNames.Cookies, null, Request.Scheme, Request.Host.Host));
+            urlList.Add(Url.RouteUrl(RouteNames.CookiesDetails, null, Request.Scheme, Request.Host.Host));
+            urlList.Add(Url.RouteUrl(RouteNames.Privacy, null, Request.Scheme, Request.Host.Host));
+            urlList.Add(Url.RouteUrl(RouteNames.AccessibilityStatement,null,Request.Scheme, Request.Host.Host));
+
+
+            var output = new StringBuilder();
+            var xml = XmlWriter.Create(output, new XmlWriterSettings { Indent = true, Async = true});
+            await xml.WriteStartDocumentAsync();
+            xml.WriteStartElement("urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+            foreach (var url in urlList)
+            {
+                xml.WriteStartElement("url");
+                xml.WriteElementString("loc", url);
+                await xml.WriteEndElementAsync();    
+            }
+            
+            await xml.WriteEndElementAsync();
+            await xml.FlushAsync();
+            xml.Dispose();
+
+            var content = output.ToString();
+
+            return new ContentResult
+            {
+                Content = content,
+                ContentType = "application/xml",
+                StatusCode = (int)HttpStatusCode.OK
+            };
         }
     }
 }


### PR DESCRIPTION
Generates sitemap for all "static" controller actions, then dynamically creates for

courses/{courseid}
and 
courses/{courseid}/provider

caches using memory cache for 20 hours