### PR TITLE
CSP-2006 Fixes multiple providers sort options issues

### DIFF
--- a/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviders.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviders.cs
@@ -519,4 +519,59 @@ public class WhenGettingCourseProviders
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ShortlistCount.Should().Be(shortlistCount);
     }
 
+    [Test, MoqAutoData]
+    public async Task Then_OrderBy_Options_Includes_Distance(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] CourseProvidersController sut,
+        GetCourseProvidersResult mediatorResult)
+    {
+        mediatorMock.Setup(x => x.Send(It.IsAny<GetCourseProvidersQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(mediatorResult);
+
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { Location = "CV1 Coventry" }) as ViewResult;
+
+        result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ProviderOrderOptions.Should().Contain(c => c.ProviderOrderBy == ProviderOrderBy.Distance);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_OrderBy_Options_Excludes_Distance(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] CourseProvidersController sut,
+        GetCourseProvidersResult mediatorResult)
+    {
+        mediatorMock.Setup(x => x.Send(It.IsAny<GetCourseProvidersQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(mediatorResult);
+
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { Location = string.Empty }) as ViewResult;
+
+        result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ProviderOrderOptions.Should().NotContain(c => c.ProviderOrderBy == ProviderOrderBy.Distance);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_Selected_OrderBy_Is_Defaulted_If_OrderBy_Is_Distance_And_Location_Is_Missing(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] CourseProvidersController sut,
+        GetCourseProvidersResult mediatorResult)
+    {
+        mediatorMock.Setup(x => x.Send(It.IsAny<GetCourseProvidersQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(mediatorResult);
+
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { Location = string.Empty, OrderBy = ProviderOrderBy.Distance }) as ViewResult;
+
+        result.As<ViewResult>().Model.As<CourseProvidersViewModel>().OrderBy.Should().Be(ProviderOrderBy.AchievementRate);
+    }
+
+    [MoqInlineAutoData(ProviderOrderBy.Distance)]
+    [MoqInlineAutoData(ProviderOrderBy.AchievementRate)]
+    [MoqInlineAutoData(ProviderOrderBy.EmployerProviderRating)]
+    [MoqInlineAutoData(ProviderOrderBy.ApprenticeProviderRating)]
+    public async Task Then_Selected_OrderBy_Is_Unchanged(
+        ProviderOrderBy expectedOrderBy,
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] CourseProvidersController sut,
+        GetCourseProvidersResult mediatorResult)
+    {
+        mediatorMock.Setup(x => x.Send(It.IsAny<GetCourseProvidersQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(mediatorResult);
+
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { Location = "CV1 Coventry", OrderBy = expectedOrderBy }) as ViewResult;
+
+        result.As<ViewResult>().Model.As<CourseProvidersViewModel>().OrderBy.Should().Be(expectedOrderBy);
+    }
 }

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/CourseProvidersViewModelTests/WhenFilteringCourseProviders.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/CourseProvidersViewModelTests/WhenFilteringCourseProviders.cs
@@ -45,7 +45,7 @@ public sealed class WhenFilteringCourseProviders
             ReviewPeriod = "2324"
         };
 
-        _fullQueryString = "?location=M60 7RA&distance=20&deliverymodes=Provider&deliverymodes=DayRelease&deliverymodes=BlockRelease&employerproviderratings=Excellent&employerproviderratings=Good&apprenticeproviderratings=Poor&apprenticeproviderratings=VeryPoor&qarratings=Excellent&qarratings=VeryPoor";
+        _fullQueryString = "?location=M60 7RA&distance=20&deliverymodes=Provider&deliverymodes=DayRelease&deliverymodes=BlockRelease&employerproviderratings=Excellent&employerproviderratings=Good&apprenticeproviderratings=Poor&apprenticeproviderratings=VeryPoor&qarratings=Excellent&qarratings=VeryPoor&orderby=Distance";
     }
 
     [Test]

--- a/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProvidersViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProvidersViewModel.cs
@@ -35,26 +35,10 @@ public class CourseProvidersViewModel : PageLinksViewModelBase
     public string ProviderReviewsHeading { get => $"Provider reviews in {ReviewPeriodStartYear} to {ReviewPeriodEndYear}"; }
     public string CourseAchievementRateHeading { get => $"Course achievement rate in {QarPeriodStartYear} to {QarPeriodEndYear}"; }
     public List<CoursesProviderViewModel> Providers { get; set; }
-    public List<ProviderOrderByOptionViewModel> ProviderOrderOptions { get => GenerateProviderOrderDropdown(); }
-
+    public List<ProviderOrderByOptionViewModel> ProviderOrderOptions { get; set; } = [];
     public PaginationViewModel Pagination { get; set; }
 
-    private List<ProviderOrderByOptionViewModel> GenerateProviderOrderDropdown()
-    {
-        var dropdown = new List<ProviderOrderByOptionViewModel>();
 
-        foreach (ProviderOrderBy orderByChoice in Enum.GetValues(typeof(ProviderOrderBy)))
-        {
-            dropdown.Add(new ProviderOrderByOptionViewModel
-            {
-                ProviderOrderBy = orderByChoice,
-                Description = orderByChoice.GetDescription(),
-                Selected = orderByChoice == OrderBy
-            });
-        }
-
-        return dropdown;
-    }
 
     public int TotalCount { get; set; }
 
@@ -307,15 +291,17 @@ public class CourseProvidersViewModel : PageLinksViewModelBase
             AddSelectedFilter(selectedFilters, FilterType.QarRatings, selectedQars);
         }
 
+        AddSelectedFilter(selectedFilters, FilterType.OrderBy, OrderBy.ToString());
+
         if (selectedFilters.Count == 0)
         {
             return [];
         }
 
         return CreateClearFilterSections(
-                    selectedFilters,
-                    _valueFunctions,
-                [FilterType.Distance]
+                selectedFilters,
+                _valueFunctions,
+                [FilterType.Distance, FilterType.OrderBy]
             );
     }
 

--- a/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
@@ -39,9 +39,9 @@
                     <form asp-route="@RouteNames.CourseProviders" id="course-providers-order-form" method="GET">
                         @foreach (var q in Context.Request.Query)
                         {
-                            switch (q.Key)
+                            switch (q.Key.ToLower())
                             {
-                                case "OrderBy":
+                                case "orderby":
                                     continue;
                                 case "location":
                                     <input type="hidden" name="@q.Key" value="@q.Value"/>


### PR DESCRIPTION
When clearing a single the filter then the sort order should be persisted. 
When clearing location filter and the sort order is distance then the sort order should change to `AchievementRate`.
When location is not given then the sort options should not include `Distance`