### PR TITLE
CSP-2463 Refactored all usages of course/standard identifiers to use LarsCode instead of Id or TrainingCode.

### DIFF
--- a/src/SFA.DAS.FAT.Application.UnitTests/CourseProviders/WhenGettingCourseProviders.cs
+++ b/src/SFA.DAS.FAT.Application.UnitTests/CourseProviders/WhenGettingCourseProviders.cs
@@ -80,7 +80,7 @@ public class WhenGettingCourseProviders
         await sut.Handle(query, cancellationToken);
 
         mockCourseService.Verify(x => x.GetCourseProviders(It.Is<CourseProvidersParameters>(
-            c => c.Id == query.Id
+            c => c.LarsCode == query.LarsCode
             && c.OrderBy == orderBy
             && c.Distance == query.Distance
             && c.Location == query.Location
@@ -115,7 +115,7 @@ public class WhenGettingCourseProviders
     {
         return new CourseProvidersParameters
         {
-            Id = request.Id,
+            LarsCode = request.LarsCode,
             OrderBy = request.OrderBy ?? ProviderOrderBy.Distance,
             Distance = request.Distance,
             Location = request.Location,

--- a/src/SFA.DAS.FAT.Application.UnitTests/Services/WhenGettingCourseProviders.cs
+++ b/src/SFA.DAS.FAT.Application.UnitTests/Services/WhenGettingCourseProviders.cs
@@ -29,7 +29,7 @@ public class WhenGettingCourseProviders
     {
         var courseProvidersParams = new CourseProvidersParameters
         {
-            Id = query.Id,
+            LarsCode = query.LarsCode,
             OrderBy = ProviderOrderBy.Distance,
             Distance = query.Distance,
             Location = query.Location,
@@ -63,7 +63,7 @@ public class WhenGettingCourseProviders
 
         var courseProvidersParams = new CourseProvidersParameters
         {
-            Id = query.Id,
+            LarsCode = query.LarsCode,
             OrderBy = ProviderOrderBy.Distance,
             Distance = query.Distance,
             Location = query.Location,
@@ -105,7 +105,7 @@ public class WhenGettingCourseProviders
         //Arrange
         var courseProvidersParams = new CourseProvidersParameters
         {
-            Id = id,
+            LarsCode = id,
             OrderBy = orderBy,
             Distance = distance,
             Location = location,
@@ -176,7 +176,7 @@ public class WhenGettingCourseProviders
 
         var courseProvidersParams = new CourseProvidersParameters
         {
-            Id = id,
+            LarsCode = id,
             OrderBy = orderBy,
             Distance = distance,
             Location = location,

--- a/src/SFA.DAS.FAT.Application/CourseProviders/Query/GetCourseProviders/GetCourseProvidersQuery.cs
+++ b/src/SFA.DAS.FAT.Application/CourseProviders/Query/GetCourseProviders/GetCourseProvidersQuery.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.FAT.Application.CourseProviders.Query.GetCourseProviders;
 
 public class GetCourseProvidersQuery : IRequest<GetCourseProvidersResult>
 {
-    public string Id { get; set; }
+    public string LarsCode { get; set; }
     public ProviderOrderBy? OrderBy { get; set; }
     public int? Distance { get; set; }
     public string Location { get; set; } = string.Empty;

--- a/src/SFA.DAS.FAT.Application/CourseProviders/Query/GetCourseProviders/GetCourseProvidersQueryHandler.cs
+++ b/src/SFA.DAS.FAT.Application/CourseProviders/Query/GetCourseProviders/GetCourseProvidersQueryHandler.cs
@@ -5,6 +5,7 @@ using SFA.DAS.FAT.Domain.CourseProviders;
 using SFA.DAS.FAT.Domain.Interfaces;
 
 namespace SFA.DAS.FAT.Application.CourseProviders.Query.GetCourseProviders;
+
 public class GetCourseProvidersQueryHandler : IRequestHandler<GetCourseProvidersQuery, GetCourseProvidersResult>
 {
     private readonly ICourseService _courseService;
@@ -20,7 +21,7 @@ public class GetCourseProvidersQueryHandler : IRequestHandler<GetCourseProviders
     {
         var courseProvidersParameters = new CourseProvidersParameters
         {
-            Id = request.Id,
+            LarsCode = request.LarsCode,
             OrderBy = request.OrderBy ?? ProviderOrderBy.Distance,
             Distance = request.Distance,
             Location = request.Location,

--- a/src/SFA.DAS.FAT.Domain/CourseProviders/Api/CourseProvidersApiRequest.cs
+++ b/src/SFA.DAS.FAT.Domain/CourseProviders/Api/CourseProvidersApiRequest.cs
@@ -21,12 +21,12 @@ public class CourseProvidersApiRequest : IGetApiRequest
     private readonly int? _page;
     private readonly int? _pageSize;
     private readonly Guid? _shortlistUserId;
-    private readonly string _id;
+    private readonly string _larsCode;
 
     public CourseProvidersApiRequest(string baseUrl, CourseProvidersParameters courseProvidersParameters)
     {
         BaseUrl = baseUrl;
-        _id = courseProvidersParameters.Id;
+        _larsCode = courseProvidersParameters.LarsCode;
         _orderBy = courseProvidersParameters.OrderBy;
         _distance = courseProvidersParameters.Distance;
         _location = courseProvidersParameters.Location;
@@ -44,7 +44,7 @@ public class CourseProvidersApiRequest : IGetApiRequest
 
     private string BuildUrl()
     {
-        var buildUrl = $"{BaseUrl}courses/{_id}/providers?orderBy={_orderBy}";
+        var buildUrl = $"{BaseUrl}courses/{_larsCode}/providers?orderBy={_orderBy}";
 
         buildUrl = AddDistanceToUrl(buildUrl);
         buildUrl = AddLocationToUrl(buildUrl);

--- a/src/SFA.DAS.FAT.Domain/CourseProviders/CourseProvidersParameters.cs
+++ b/src/SFA.DAS.FAT.Domain/CourseProviders/CourseProvidersParameters.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.FAT.Domain.CourseProviders;
 
 public class CourseProvidersParameters
 {
-    public string Id { get; set; }
+    public string LarsCode { get; set; }
     public ProviderOrderBy OrderBy { get; set; }
     public int? Distance { get; set; }
     public string Location { get; set; }

--- a/src/SFA.DAS.FAT.Domain/CourseProviders/LocationType.cs
+++ b/src/SFA.DAS.FAT.Domain/CourseProviders/LocationType.cs
@@ -4,5 +4,6 @@ public enum LocationType
 {
     Provider,
     National,
-    Regional
+    Regional,
+    Online
 }

--- a/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviderDetails.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviderDetails.cs
@@ -76,7 +76,7 @@ public class WhenGettingCourseProviderDetails
 
     [Test, MoqAutoData]
     public async Task When_Provider_Details_Are_Found_Then_Values_Are_Mapped_To_Model_Correctly(
-        string courseId,
+        string larsCode,
         int providerId,
         string location,
         GetCourseProviderQueryResult response,
@@ -92,14 +92,14 @@ public class WhenGettingCourseProviderDetails
         var distance = 10;
         response.AnnualApprenticeFeedbackDetails = new List<ApprenticeFeedbackAnnualSummaries>();
         response.AnnualEmployerFeedbackDetails = new List<EmployerFeedbackAnnualSummaries>();
-
+        response.LarsCode = larsCode;
         shortlistCookieServiceMock.Setup(x =>
             x.Get(Constants.ShortlistCookieName))
         .Returns(shortlistCookieItem);
 
         mediator.Setup(x => x.Send(It.Is<GetCourseProviderDetailsQuery>(c =>
                 c.Ukprn.Equals(providerId) &&
-                c.LarsCode.Equals(courseId) &&
+                c.LarsCode.Equals(larsCode) &&
                 c.Location.Equals(location) &&
                 c.Distance.Equals(DistanceService.DEFAULT_DISTANCE) &&
                 c.ShortlistUserId.Equals(shortlistCookieItem.ShortlistUserId)
@@ -116,14 +116,14 @@ public class WhenGettingCourseProviderDetails
             )
         ).ReturnsAsync(new ValidationResult());
 
-        var result = await sut.CourseProviderDetails(courseId, providerId, location, distance.ToString());
+        var result = await sut.CourseProviderDetails(larsCode, providerId, location, distance.ToString());
 
         Assert.That(result, Is.Not.Null);
 
         mediator.Verify(a =>
              a.Send(
                  It.Is<GetCourseProviderDetailsQuery>(q =>
-                     q.LarsCode == courseId &&
+                     q.LarsCode == larsCode &&
                      q.Ukprn == providerId &&
                      q.Location == location &&
                      q.Distance == DistanceService.DEFAULT_DISTANCE &&
@@ -158,7 +158,7 @@ public class WhenGettingCourseProviderDetails
             Assert.That(model.ShortlistId, Is.EqualTo(response.ShortlistId));
             Assert.That(model.Locations, Is.EqualTo(response.Locations));
             Assert.That(model.Courses, Is.EqualTo(expectedCoursesAlphabetically));
-            Assert.That(model.CourseId, Is.EqualTo(courseId));
+            Assert.That(model.LarsCode, Is.EqualTo(larsCode));
             Assert.That(model.Location, Is.EqualTo(location));
             Assert.That(model.Distance, Is.EqualTo(distance.ToString()));
             Assert.That(model.ShowApprenticeTrainingCourseProvidersCrumb, Is.True);

--- a/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviders.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Controllers/CourseProvidersControllerTests/WhenGettingCourseProviders.cs
@@ -76,7 +76,7 @@ public class WhenGettingCourseProviders
             .Returns(new ShortlistCookieItem { ShortlistUserId = shortlistUserId });
 
         mediator.Setup(x => x.Send(
-                It.Is<GetCourseProvidersQuery>(c => c.Id.Equals(request.Id)
+                It.Is<GetCourseProvidersQuery>(c => c.LarsCode.Equals(request.LarsCode)
                  && c.Location.Equals(request.Location)
                  && c.OrderBy.Equals(request.OrderBy)
                  && c.DeliveryModes.SequenceEqual(request.DeliveryModes)
@@ -107,7 +107,7 @@ public class WhenGettingCourseProviders
             var actualModel = sut!.Model as CourseProvidersViewModel;
             actualModel.Should().NotBeNull();
             actualModel!.CourseTitleAndLevel.Should().Be(response.StandardName);
-            actualModel.CourseId.Should().Be(request.Id.ToString());
+            actualModel.LarsCode.Should().Be(request.LarsCode.ToString());
             actualModel.Location.Should().Be(request.Location ?? string.Empty);
             actualModel.Distance.Should().Be(DistanceService.TEN_MILES.ToString());
             actualModel.SelectedDeliveryModes = request.DeliveryModes.Where(dm => dm != ProviderDeliveryMode.Provider)
@@ -158,7 +158,7 @@ public class WhenGettingCourseProviders
             .Returns((ShortlistCookieItem)null);
 
         mediator.Setup(x => x.Send(
-                It.Is<GetCourseProvidersQuery>(c => c.Id.Equals(request.Id)
+                It.Is<GetCourseProvidersQuery>(c => c.LarsCode.Equals(request.LarsCode)
                  && c.Location.Equals(request.Location)
                  && c.OrderBy.Equals(request.OrderBy)
                  && c.DeliveryModes.SequenceEqual(request.DeliveryModes)
@@ -899,7 +899,7 @@ public class WhenGettingCourseProviders
                 It.IsAny<CancellationToken>()
             ))
             .ReturnsAsync(new ValidationResult());
-        var result = await sut.CourseProviders(new CourseProvidersRequest() { Id = "1" }) as ViewResult;
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { LarsCode = "1" }) as ViewResult;
 
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ShortlistCount.Should().Be(shortlistCount);
     }
@@ -923,7 +923,7 @@ public class WhenGettingCourseProviders
             ))
             .ReturnsAsync(new ValidationResult());
 
-        var result = await sut.CourseProviders(new CourseProvidersRequest() { Id = "1", Location = "CV1 Coventry" }) as ViewResult;
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { LarsCode = "1", Location = "CV1 Coventry" }) as ViewResult;
 
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ProviderOrderOptions.Should().Contain(c => c.ProviderOrderBy == ProviderOrderBy.Distance);
     }
@@ -947,7 +947,7 @@ public class WhenGettingCourseProviders
             ))
             .ReturnsAsync(new ValidationResult());
 
-        var result = await sut.CourseProviders(new CourseProvidersRequest() { Id = "1", Location = string.Empty }) as ViewResult;
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { LarsCode = "1", Location = string.Empty }) as ViewResult;
 
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().ProviderOrderOptions.Should().NotContain(c => c.ProviderOrderBy == ProviderOrderBy.Distance);
     }
@@ -970,7 +970,7 @@ public class WhenGettingCourseProviders
                 It.IsAny<CancellationToken>()
             ))
             .ReturnsAsync(new ValidationResult());
-        var result = await sut.CourseProviders(new CourseProvidersRequest() { Id = "1", Location = string.Empty, OrderBy = ProviderOrderBy.Distance }) as ViewResult;
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { LarsCode = "1", Location = string.Empty, OrderBy = ProviderOrderBy.Distance }) as ViewResult;
 
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().OrderBy.Should().Be(ProviderOrderBy.AchievementRate);
     }
@@ -997,7 +997,7 @@ public class WhenGettingCourseProviders
                 It.IsAny<CancellationToken>()
             ))
             .ReturnsAsync(new ValidationResult());
-        var result = await sut.CourseProviders(new CourseProvidersRequest() { Id = "1", Location = "CV1 Coventry", OrderBy = expectedOrderBy }) as ViewResult;
+        var result = await sut.CourseProviders(new CourseProvidersRequest() { LarsCode = "1", Location = "CV1 Coventry", OrderBy = expectedOrderBy }) as ViewResult;
 
         result.As<ViewResult>().Model.As<CourseProvidersViewModel>().OrderBy.Should().Be(expectedOrderBy);
     }

--- a/src/SFA.DAS.FAT.Web.UnitTests/Controllers/ShortlistControllerTests/WhenDeletingShortlistItem.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Controllers/ShortlistControllerTests/WhenDeletingShortlistItem.cs
@@ -65,8 +65,8 @@ public class WhenDeletingShortlistItem
         //Assert
         actual.Should().NotBeNull();
         actual.RouteName.Should().Be(RouteNames.CourseProviders);
-        actual.RouteValues.Should().ContainKey("id");
-        actual.RouteValues["id"].Should().Be(request.TrainingCode);
+        actual.RouteValues.Should().ContainKey("larsCode");
+        actual.RouteValues["larsCode"].Should().Be(request.LarsCode);
         actual.RouteValues.Should().ContainKey("providerId");
         actual.RouteValues["providerId"].Should().Be(request.Ukprn);
         protector.Verify(c => c.Protect(It.IsAny<byte[]>()), Times.Never);

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/CourseViewModelTests/WhenBuildingCourseViewModelFromQueryResult.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/CourseViewModelTests/WhenBuildingCourseViewModelFromQueryResult.cs
@@ -8,6 +8,7 @@ using SFA.DAS.FAT.Web.Models;
 using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FAT.Web.UnitTests.Models.CourseViewModelTests;
+
 public class WhenBuildingCourseViewModelFromQueryResult
 {
     [Test, MoqAutoData]
@@ -38,7 +39,7 @@ public class WhenBuildingCourseViewModelFromQueryResult
             Assert.That(sut.StandardPageUrl, Is.EqualTo(source.StandardPageUrl));
             Assert.That(sut.IsFoundationApprenticeship, Is.EqualTo(isFoundationApprenticeship));
             Assert.That(sut.Levels, Is.EqualTo(source.Levels));
-            Assert.That(sut.CourseId, Is.EqualTo(source.LarsCode));
+            Assert.That(sut.LarsCode, Is.EqualTo(source.LarsCode));
             Assert.That(sut.ShowShortListLink, Is.True);
             Assert.That(sut.ShowApprenticeTrainingCoursesCrumb, Is.True);
             Assert.That(sut.ApprenticeshipType, Is.EqualTo(source.ApprenticeshipType));

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelFilterTests/WhenFilteringCourses.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelFilterTests/WhenFilteringCourses.cs
@@ -471,7 +471,7 @@ public sealed class WhenFilteringCourses
         var values = _coursesViewModel.GenerateStandardRouteValues("55");
         Assert.Multiple(() =>
         {
-            Assert.That(values["id"], Is.EqualTo("55"));
+            Assert.That(values["larsCode"], Is.EqualTo("55"));
             Assert.That(values.ContainsKey("location"), Is.True);
             Assert.That(values.ContainsKey("distance"), Is.True);
             Assert.That(values["location"], Is.EqualTo("M60 7RA"));

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelTests/WhenCreatingCoursesViewModel.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelTests/WhenCreatingCoursesViewModel.cs
@@ -504,8 +504,8 @@ public class WhenCreatingCoursesViewModel
 
         Assert.Multiple(() =>
         {
-            Assert.That(result.ContainsKey("id"), Is.True);
-            Assert.That(result["id"], Is.EqualTo(larsCode.ToString()));
+            Assert.That(result.ContainsKey("larsCode"), Is.True);
+            Assert.That(result["larsCode"], Is.EqualTo(larsCode));
 
             Assert.That(result.ContainsKey("location"), Is.True);
             Assert.That(result["location"], Is.EqualTo(_sut.Location));
@@ -530,8 +530,8 @@ public class WhenCreatingCoursesViewModel
 
         Assert.Multiple(() =>
         {
-            Assert.That(result.ContainsKey("id"), Is.True);
-            Assert.That(result["id"], Is.EqualTo(larsCode.ToString()));
+            Assert.That(result.ContainsKey("larsCode"), Is.True);
+            Assert.That(result["larsCode"], Is.EqualTo(larsCode.ToString()));
 
             Assert.That(result.ContainsKey("location"), Is.False);
             Assert.That(result.ContainsKey("distance"), Is.False);
@@ -553,8 +553,8 @@ public class WhenCreatingCoursesViewModel
 
         Assert.Multiple(() =>
         {
-            Assert.That(result.ContainsKey("id"), Is.True);
-            Assert.That(result["id"], Is.EqualTo(larsCode.ToString()));
+            Assert.That(result.ContainsKey("larsCode"), Is.True);
+            Assert.That(result["larsCode"], Is.EqualTo(larsCode));
 
             Assert.That(result.ContainsKey("location"), Is.False);
             Assert.That(result.ContainsKey("distance"), Is.False);
@@ -584,8 +584,8 @@ public class WhenCreatingCoursesViewModel
             It.Is<UrlRouteContext>(c =>
                 c.RouteName == RouteNames.CourseProviders
                 && c.Values != null
-                && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("id")
-                && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["id"], standardViewModel.LarsCode)
+                && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("larsCode")
+                && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["larsCode"], standardViewModel.LarsCode)
                 && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("Location")
                 && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["Location"], _sut.Location)
                 && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("distance")

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelTests/WhenCreatingCoursesViewModel.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/CoursesViewModelTests/WhenCreatingCoursesViewModel.cs
@@ -617,8 +617,8 @@ public class WhenCreatingCoursesViewModel
             It.Is<UrlRouteContext>(c =>
                 c.RouteName == RouteNames.CourseProviders
                 && c.Values != null
-                && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("id")
-                && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["id"], standardViewModel.LarsCode)
+                && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("larsCode")
+                && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["larsCode"], standardViewModel.LarsCode)
                 && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("Location")
                 && Equals(new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values)["Location"], _sut.Location)
                 && new Microsoft.AspNetCore.Routing.RouteValueDictionary(c.Values).ContainsKey("distance")

--- a/src/SFA.DAS.FAT.Web.UnitTests/Models/WhenBuildingCourseProviderTopPanelViewModelTests.cs
+++ b/src/SFA.DAS.FAT.Web.UnitTests/Models/WhenBuildingCourseProviderTopPanelViewModelTests.cs
@@ -5,6 +5,7 @@ using SFA.DAS.FAT.Web.Services;
 using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FAT.Web.UnitTests.Models;
+
 public class WhenBuildingCourseProviderTopPanelViewModelTests
 {
     [Test]
@@ -20,7 +21,7 @@ public class WhenBuildingCourseProviderTopPanelViewModelTests
         var expectedDictionary = new Dictionary<string, string>
         {
             {"location", sut.Location},
-            {"id", sut.CourseId},
+            {"larsCode", sut.LarsCode},
             {"providerId", sut.Ukprn.ToString()},
             {"distance", distanceExpected}
         };

--- a/src/SFA.DAS.FAT.Web/Controllers/CourseProvidersController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/CourseProvidersController.cs
@@ -25,7 +25,7 @@ using SFA.DAS.FAT.Web.Services;
 
 namespace SFA.DAS.FAT.Web.Controllers;
 
-[Route("courses/{id}/providers")]
+[Route("courses/{larsCode}/providers")]
 public class CourseProvidersController : Controller
 {
     public const string LocationTempDataKey = "Location";
@@ -61,7 +61,7 @@ public class CourseProvidersController : Controller
     [Route("", Name = RouteNames.CourseProviders)]
     public async Task<IActionResult> CourseProviders(CourseProvidersRequest request)
     {
-        var validationLarsCodeResult = await _courseIdValidator.ValidateAsync(new GetCourseQuery { LarsCode = request.Id });
+        var validationLarsCodeResult = await _courseIdValidator.ValidateAsync(new GetCourseQuery { LarsCode = request.LarsCode });
 
         if (!validationLarsCodeResult.IsValid)
         {
@@ -92,7 +92,7 @@ public class CourseProvidersController : Controller
 
         var result = await _mediator.Send(new GetCourseProvidersQuery
         {
-            Id = request.Id,
+            LarsCode = request.LarsCode,
             Location = request.Location,
             OrderBy = orderBy,
             Distance = convertedDistance,
@@ -111,11 +111,10 @@ public class CourseProvidersController : Controller
 
         var courseProvidersViewModel = new CourseProvidersViewModel(_config)
         {
-            Id = request.Id,
+            LarsCode = request.LarsCode,
             ShortlistCount = shortlistCount?.Count ?? 0,
             OrderBy = orderBy,
             CourseTitleAndLevel = result.StandardName,
-            CourseId = request.Id.ToString(),
             Location = request.Location,
             Distance = convertedDistance.ToString(),
             SelectedDeliveryModes = deliveryModes.Select(d => d.ToString()).ToList(),
@@ -163,7 +162,7 @@ public class CourseProvidersController : Controller
     }
 
     [Route("{providerId}", Name = RouteNames.CourseProviderDetails)]
-    public async Task<IActionResult> CourseProviderDetails(string id, int providerId, string location, string distance)
+    public async Task<IActionResult> CourseProviderDetails(string larsCode, int providerId, string location, string distance)
     {
 
         var validationUkprnResult = await _ukprnValidator.ValidateAsync(new GetCourseProviderDetailsQuery { Ukprn = providerId });
@@ -173,7 +172,7 @@ public class CourseProvidersController : Controller
             return NotFound();
         }
 
-        var validationLarsCodeResult = await _courseIdValidator.ValidateAsync(new GetCourseQuery { LarsCode = id });
+        var validationLarsCodeResult = await _courseIdValidator.ValidateAsync(new GetCourseQuery { LarsCode = larsCode });
 
         if (!validationLarsCodeResult.IsValid)
         {
@@ -192,7 +191,7 @@ public class CourseProvidersController : Controller
         var query = new GetCourseProviderDetailsQuery
         {
             Ukprn = providerId,
-            LarsCode = id,
+            LarsCode = larsCode,
             Location = location?.Trim(),
             Distance = string.IsNullOrWhiteSpace(location) ? null : DistanceService.DEFAULT_DISTANCE,
             ShortlistUserId = shortlistUserId
@@ -208,7 +207,7 @@ public class CourseProvidersController : Controller
         var viewModel = (CourseProviderViewModel)result;
         viewModel.FeedbackSurvey = FeedbackSurveyViewModel.ProcessFeedbackDetails(result.AnnualEmployerFeedbackDetails,
             result.AnnualApprenticeFeedbackDetails, _dateTimeService.GetDateTime());
-        viewModel.CourseId = id;
+        viewModel.LarsCode = larsCode;
         viewModel.Location = location;
         viewModel.Distance = distance ?? DistanceService.TEN_MILES.ToString();
         viewModel.ShortlistId = result.ShortlistId;

--- a/src/SFA.DAS.FAT.Web/Controllers/CourseProvidersController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/CourseProvidersController.cs
@@ -162,7 +162,7 @@ public class CourseProvidersController : Controller
     }
 
     [Route("{providerId}", Name = RouteNames.CourseProviderDetails)]
-    public async Task<IActionResult> CourseProviderDetails(string larsCode, int providerId, string location, string distance)
+    public async Task<IActionResult> CourseProviderDetails([FromRoute] string larsCode, [FromRoute] int providerId, [FromQuery] string location, [FromQuery] string distance)
     {
 
         var validationUkprnResult = await _ukprnValidator.ValidateAsync(new GetCourseProviderDetailsQuery { Ukprn = providerId });

--- a/src/SFA.DAS.FAT.Web/Controllers/CoursesController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/CoursesController.cs
@@ -93,8 +93,8 @@ public class CoursesController : Controller
         return View(viewModel);
     }
 
-    [Route("{id}", Name = RouteNames.CourseDetails)]
-    public async Task<IActionResult> CourseDetails([FromRoute] string id, [FromQuery] string location, [FromQuery] string distance)
+    [Route("{larsCode}", Name = RouteNames.CourseDetails)]
+    public async Task<IActionResult> CourseDetails([FromRoute] string larsCode, [FromQuery] string location, [FromQuery] string distance)
     {
         int? convertedDistance = null;
         if (distance == DistanceService.ACROSS_ENGLAND_FILTER_VALUE)
@@ -113,7 +113,7 @@ public class CoursesController : Controller
 
         var query = new GetCourseQuery()
         {
-            LarsCode = id,
+            LarsCode = larsCode,
             Location = location,
             Distance = convertedDistance
         };

--- a/src/SFA.DAS.FAT.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/HomeController.cs
@@ -76,8 +76,8 @@ public class HomeController : Controller
             Url.RouteUrl(RouteNames.Courses,null,Request.Scheme, Request.Host.Host),
 
         };
-        urlList.AddRange(result.Standards.Select(course => Url.RouteUrl(RouteNames.CourseDetails, new { id = course.LarsCode }, Request.Scheme, Request.Host.Host)));
-        urlList.AddRange(result.Standards.Select(course => Url.RouteUrl(RouteNames.CourseProviders, new { id = course.LarsCode }, Request.Scheme, Request.Host.Host)));
+        urlList.AddRange(result.Standards.Select(course => Url.RouteUrl(RouteNames.CourseDetails, new { larsCode = course.LarsCode }, Request.Scheme, Request.Host.Host)));
+        urlList.AddRange(result.Standards.Select(course => Url.RouteUrl(RouteNames.CourseProviders, new { larsCode = course.LarsCode }, Request.Scheme, Request.Host.Host)));
 
         urlList.Add(Url.RouteUrl(RouteNames.ShortLists, null, Request.Scheme, Request.Host.Host));
         urlList.Add(Url.RouteUrl(RouteNames.Cookies, null, Request.Scheme, Request.Host.Host));

--- a/src/SFA.DAS.FAT.Web/Controllers/ShortlistController.cs
+++ b/src/SFA.DAS.FAT.Web/Controllers/ShortlistController.cs
@@ -181,7 +181,7 @@ public class ShortlistController : Controller
             TempData[RemovedProviderNameTempDataKey] = request.ProviderName;
             return RedirectToRoute(request.RouteName, new
             {
-                Id = request.TrainingCode,
+                LarsCode = request.LarsCode,
                 ProviderId = request.Ukprn
             });
         }

--- a/src/SFA.DAS.FAT.Web/Models/BreadCrumbs/PageLinksViewModelBase.cs
+++ b/src/SFA.DAS.FAT.Web/Models/BreadCrumbs/PageLinksViewModelBase.cs
@@ -8,6 +8,6 @@ public class PageLinksViewModelBase
     public bool ShowApprenticeTrainingCourseProvidersCrumb { get; set; }
     public string Location { get; set; }
     public string Distance { get; set; }
-    public string CourseId { get; set; }
+    public string LarsCode { get; set; }
     public bool ShowShortListLink { get; set; }
 }

--- a/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProviderTopPanelViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProviderTopPanelViewModel.cs
@@ -11,7 +11,7 @@ public class CourseProviderTopPanelViewModel
     public Guid? ShortlistId { get; set; }
     public int ShortlistCount { get; set; }
     public string Location { get; set; }
-    public string CourseId { get; set; }
+    public string LarsCode { get; set; }
     public string Distance { get; set; }
 
     public Dictionary<string, string> ProviderRouteData
@@ -27,7 +27,7 @@ public class CourseProviderTopPanelViewModel
             var providerRouteData = new Dictionary<string, string>
             {
                 { "location", Location },
-                { "id", CourseId },
+                { "larsCode", LarsCode },
                 { "providerId", Ukprn.ToString() },
                 { "distance", distance }
             };

--- a/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProvidersViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseProviders/CourseProvidersViewModel.cs
@@ -17,7 +17,6 @@ namespace SFA.DAS.FAT.Web.Models.CourseProviders;
 
 public class CourseProvidersViewModel : PageLinksViewModelBase
 {
-    public string Id { get; set; }
     public int ShortlistCount { get; set; }
     public ProviderOrderBy OrderBy { get; set; }
     public string CourseTitleAndLevel { get; set; } = string.Empty;

--- a/src/SFA.DAS.FAT.Web/Models/CourseProvidersRequest.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseProvidersRequest.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.FAT.Web.Models;
 public class CourseProvidersRequest
 {
     [FromRoute]
-    public string Id { get; set; }
+    public string LarsCode { get; set; }
 
     [FromQuery]
     public ProviderOrderBy OrderBy { get; set; } = ProviderOrderBy.Distance;

--- a/src/SFA.DAS.FAT.Web/Models/CourseViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseViewModel.cs
@@ -13,7 +13,6 @@ public class CourseViewModel : PageLinksViewModelBase
 {
     public string StandardUId { get; set; }
     public string IFateReferenceNumber { get; set; }
-    public string LarsCode { get; set; }
     public int ProvidersCountWithinDistance { get; set; }
     public int TotalProvidersCount { get; set; }
     public string Title { get; set; }

--- a/src/SFA.DAS.FAT.Web/Models/CourseViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CourseViewModel.cs
@@ -59,7 +59,6 @@ public class CourseViewModel : PageLinksViewModelBase
             StandardPageUrl = source.StandardPageUrl,
             KsbDetails = KsbsGroupsOrdered(source.Ksbs),
             Levels = source.Levels,
-            CourseId = source.LarsCode,
             ShowShortListLink = true,
             ShowApprenticeTrainingCoursesCrumb = true,
             IsFoundationApprenticeship = source.ApprenticeshipType == ApprenticeshipType.FoundationApprenticeship,

--- a/src/SFA.DAS.FAT.Web/Models/CoursesViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/CoursesViewModel.cs
@@ -156,7 +156,7 @@ public class CoursesViewModel : PageLinksViewModelBase
     {
         if (standard.ProvidersCount > 0)
         {
-            return _urlHelper.RouteUrl(RouteNames.CourseProviders, new { id = standard.LarsCode, Location, distance = Distance == DistanceService.ACROSS_ENGLAND_FILTER_VALUE ? "" : Distance })!;
+            return _urlHelper.RouteUrl(RouteNames.CourseProviders, new { larsCode = standard.LarsCode, Location, distance = Distance == DistanceService.ACROSS_ENGLAND_FILTER_VALUE ? "" : Distance })!;
         }
 
         return GetHelpFindingCourseUrl(standard.LarsCode);
@@ -374,7 +374,7 @@ public class CoursesViewModel : PageLinksViewModelBase
     {
         var routeValues = new Dictionary<string, string>
         {
-            { "id", larsCode.ToString() },
+            { "larsCode", larsCode.ToString() },
         };
 
         if (!string.IsNullOrWhiteSpace(Location))

--- a/src/SFA.DAS.FAT.Web/Models/DeleteShortlistItemRequest.cs
+++ b/src/SFA.DAS.FAT.Web/Models/DeleteShortlistItemRequest.cs
@@ -5,11 +5,11 @@ namespace SFA.DAS.FAT.Web.Models
 {
     public class DeleteShortlistItemRequest
     {
-        [FromRoute(Name="id")]
+        [FromRoute(Name = "id")]
         public Guid ShortlistId { get; set; }
-        public int? Ukprn { get ; set ; }
-        public string ProviderName { get ; set ; }
-        public int? TrainingCode { get ; set ; }
+        public int? Ukprn { get; set; }
+        public string ProviderName { get; set; }
+        public string LarsCode { get; set; }
         public string RouteName { get; set; }
     }
 }

--- a/src/SFA.DAS.FAT.Web/Models/Providers/ProviderDetailsViewModel.cs
+++ b/src/SFA.DAS.FAT.Web/Models/Providers/ProviderDetailsViewModel.cs
@@ -61,7 +61,7 @@ public class ProviderDetailsViewModel : PageLinksViewModelBase
             {
                 var routeData = new Dictionary<string, string>
                 {
-                    { "id", course.LarsCode.ToString() },
+                    { "larsCode", course.LarsCode.ToString() },
                     { "providerId", vm.Ukprn.ToString() }
                 };
 

--- a/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviderDetails.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviderDetails.cshtml
@@ -50,7 +50,7 @@
 
                     <a class="govuk-link govuk-link--no-visited-state"
                        asp-route="@RouteNames.CourseProviderDetails"
-                       asp-route-id="@Model.LarsCode"
+                       asp-route-larsCode="@Model.LarsCode"
                        asp-route-providerId="@Model.Ukprn">
                         remove or change your location
                     </a>.
@@ -557,7 +557,7 @@
                         {
                             <li class="govuk-task-list__item govuk-task-list__item--with-link">
                                 <div class="govuk-task-list__name-and-hint">
-                                    <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.CourseProviderDetails" asp-route-id="@course.LarsCode" asp-route-providerId="@Model.Ukprn" asp-route-location="@Model.Location" asp-route-distance="@Model.Distance">
+                                    <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.CourseProviderDetails" asp-route-larsCode="@course.LarsCode" asp-route-providerId="@Model.Ukprn" asp-route-location="@Model.Location" asp-route-distance="@Model.Distance">
                                         @course.NameAndLevel
                                     </a>
                                 </div>
@@ -591,7 +591,7 @@
                     <div class="app-provider-shortlist-control app-provider-shortlist-control--inline @Model.ShortlistClass">
                         <div class="app-provider-shortlist-add">
                             <form method="post" asp-route="@RouteNames.CreateShortlistItem">
-                                <input type="hidden" name="larsCode" value="@Model.CourseId" />
+                                <input type="hidden" name="larsCode" value="@Model.LarsCode" />
                                 <input type="hidden" name="ukprn" value="@Model.Ukprn" />
                                 <input type="hidden" name="providerName" value="@Model.ProviderName" />
                                 <input type="hidden" name="routeName" value="@RouteNames.CourseProviderDetails" />
@@ -610,7 +610,7 @@
                             <form method="post" asp-route="@RouteNames.DeleteShortlistItem" asp-route-id="@(Model.ShortlistId ?? Guid.Empty)">
                                 <input type="hidden" name="ukprn" value="@Model.Ukprn" />
                                 <input type="hidden" name="providerName" value="@Model.ProviderName" />
-                                <input type="hidden" name="trainingCode" value="@Model.CourseId" />
+                                <input type="hidden" name="larsCode" value="@Model.LarsCode" />
                                 <input type="hidden" name="routeName" value="@RouteNames.CourseProviderDetails" />
                                 <button id="remove-from-shortlist-@(Model.Ukprn)" class="das-button--inline-link das-no-wrap" type="submit">Remove from shortlist</button>
                             </form>
@@ -620,7 +620,7 @@
                     @if (Model.TotalProvidersCount > 1)
                     {
                         <p class="govuk-body govuk-!-margin-top-4">@Model.ProviderName is 1 of @Model.TotalProvidersCount training providers for @Model.CourseNameAndLevel.</p>
-                        <p class="govuk-body govuk-!-margin-bottom-0"><a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.CourseProviders" asp-route-id="@Model.CourseId">View training providers for this course</a></p>
+                        <p class="govuk-body govuk-!-margin-bottom-0"><a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.CourseProviders" asp-route-larsCode="@Model.LarsCode">View training providers for this course</a></p>
                     }
 
                     @if (Model.TotalProvidersCount == 1)

--- a/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
@@ -32,7 +32,7 @@
             </form>
         </div>
         <div class="govuk-grid-column-two-thirds">
-            <form asp-route="@RouteNames.CourseProviders" larsCode="course-providers-order-form" method="GET" class="app-search-results-header">
+            <form asp-route="@RouteNames.CourseProviders" id="course-providers-order-form" method="GET" class="app-search-results-header">
                 @foreach (var q in Context.Request.Query)
                 {
                     switch (q.Key.ToLower())

--- a/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/CourseProviders/CourseProviders.cshtml
@@ -32,7 +32,7 @@
             </form>
         </div>
         <div class="govuk-grid-column-two-thirds">
-            <form asp-route="@RouteNames.CourseProviders" id="course-providers-order-form" method="GET" class="app-search-results-header">
+            <form asp-route="@RouteNames.CourseProviders" larsCode="course-providers-order-form" method="GET" class="app-search-results-header">
                 @foreach (var q in Context.Request.Query)
                 {
                     switch (q.Key.ToLower())
@@ -112,7 +112,7 @@
                                 <div>
                                     @await Html.PartialAsync("_courseProviderTopPanel", new CourseProviderTopPanelViewModel
                                     {
-                                        CourseId = Model.Id.ToString(),
+                                        LarsCode = Model.LarsCode,
                                         ShortlistCount = Model.ShortlistCount,
                                         ProviderName = provider.ProviderName,
                                         ShortlistId = provider.ShortlistId,
@@ -178,7 +178,7 @@
                 </p>
 
                 <p class="govuk-!-margin-0">
-                    <a id="ask-training-providers-run-course" href="@Model.GetHelpFindingCourseUrl(Model.CourseId)" class="govuk-button das-button--blue govuk-!-margin-0">Ask if training providers can run this course</a>
+                    <a id="ask-training-providers-run-course" href="@Model.GetHelpFindingCourseUrl(Model.LarsCode)" class="govuk-button das-button--blue govuk-!-margin-0">Ask if training providers can run this course</a>
                 </p>
             </div>
    

--- a/src/SFA.DAS.FAT.Web/Views/CourseProviders/_courseProviderTopPanel.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/CourseProviders/_courseProviderTopPanel.cshtml
@@ -20,7 +20,7 @@
                 <div class="app-provider-shortlist-control @(Model.ShortlistId == null ? Model.ShortlistCount < ShortlistConstants.MaximumShortlistCount ? "" : "app-provider-shortlist-full" : "app-provider-shortlist-added")">
                     <div class="app-provider-shortlist-add">
                         <form method="post" asp-route="@RouteNames.CreateShortlistItem">
-                            <input type="hidden" name="larsCode" value="@Model.CourseId"/>
+                            <input type="hidden" name="larsCode" value="@Model.LarsCode"/>
                             <input type="hidden" name="ukprn" value="@Model.Ukprn"/>
                             <input type="hidden" name="providerName" value="@Model.ProviderName"/>
                             <input type="hidden" name="routeName" value="@RouteNames.CourseProviders"/>
@@ -39,7 +39,7 @@
                         <form method="post" asp-route="@RouteNames.DeleteShortlistItem" asp-route-id="@(Model.ShortlistId ?? Guid.Empty)">
                             <input type="hidden" name="ukprn" value="@Model.Ukprn"/>
                             <input type="hidden" name="providerName" value="@Model.ProviderName"/>
-                            <input type="hidden" name="trainingCode" value="@Model.CourseId"/>
+                            <input type="hidden" name="larsCode" value="@Model.LarsCode"/>
                             <input type="hidden" name="routeName" value="@RouteNames.CourseProviders"/>
                             <button id="remove-from-shortlist-@(Model.Ukprn)" class="das-button--inline-link govuk-!-font-weight-regular das-no-wrap" type="submit">Remove from shortlist</button>
                         </form>

--- a/src/SFA.DAS.FAT.Web/Views/Courses/CourseDetails.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Courses/CourseDetails.cshtml
@@ -51,7 +51,7 @@
                                 @Model.GetProviderCountDisplayMessage()
                             </p>
 
-                            <form method="GET" asp-route="@RouteNames.CourseProviders" asp-route-id="@Model.LarsCode">
+                            <form method="GET" asp-route="@RouteNames.CourseProviders" asp-route-larsCode="@Model.LarsCode">
                                 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
                                     Apprentice's work location:
                                     <span class="govuk-!-font-weight-regular">@Model.Location</span>
@@ -65,7 +65,7 @@
                                 <div class="govuk-button-group govuk-!-margin-bottom-0">
                                     <a class="govuk-button govuk-!-margin-bottom-0"
                                        asp-route="@RouteNames.CourseProviders"
-                                       asp-route-id="@Model.LarsCode"
+                                       asp-route-larsCode="@Model.LarsCode"
                                        asp-route-location="@Model.Location"
                                        asp-route-distance="@Model.Distance">
                                         View providers for this course
@@ -85,7 +85,7 @@
                             <form method="GET"
                                   id="course-location-form"
                                   asp-route="@RouteNames.CourseDetails"
-                                  asp-route-id="@Model.LarsCode"
+                                  asp-route-larsCode="@Model.LarsCode"
                                   asp-route-location="@Model.Location"
                                   asp-route-distance="@Model.Distance"
                                   class="govuk-!-width-three-quarters">
@@ -98,7 +98,7 @@
                                 </div>
                                 <a class="govuk-button govuk-!-margin-bottom-0"
                                    asp-route="@RouteNames.CourseProviders"
-                                   asp-route-id="@Model.LarsCode">
+                                   asp-route-larsCode="@Model.LarsCode">
                                     View providers for this course
                                 </a>
                             </form>

--- a/src/SFA.DAS.FAT.Web/Views/Courses/Courses.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Courses/Courses.cshtml
@@ -61,7 +61,7 @@
                                 </div>
                                 <h2 class="govuk-heading-m das-search-results__heading">
                                     <a class="das-search-results__link"
-                                       id="standard-@standard.LarsCode"
+                                       larsCode="standard-@standard.LarsCode"
                                        asp-route="@RouteNames.CourseDetails"
                                        asp-all-route-data="Model.GenerateStandardRouteValues(standard.LarsCode)">
                                         @standard.Title <span class="das-no-wrap">(level @standard.Level)</span>
@@ -103,7 +103,7 @@
                                     }
 
                                     <a class="das-search-results__link"
-                                       id="standard-@standard.LarsCode"
+                                       larsCode="standard-@standard.LarsCode"
                                        href="@Model.GetProvidersLink(standard)">
                                         @Model.GetProvidersLinkDisplayMessage(standard)<span class="govuk-visually-hidden"> - @standard.Title (level @standard.Level)</span>
                                     </a>

--- a/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
@@ -16,34 +16,34 @@
                         </a>
                     </li>
 
-                    <li asp-show="pageLinks.ShowApprenticeTrainingCoursesCrumb" class="govuk-breadcrumbs__list-item">
+                    <li asp-show="@Model.ShowApprenticeTrainingCoursesCrumb" class="govuk-breadcrumbs__list-item">
                         <a id="courses-breadcrumb"
                            class="govuk-breadcrumbs__link"
                            asp-route="@RouteNames.Courses"
-                           asp-route-location="@pageLinks.Location"
-                           asp-route-distance="@pageLinks.Distance">
+                           asp-route-location="@Model.Location"
+                           asp-route-distance="@Model.Distance">
                             Course search results
                         </a>
                     </li>
 
-                    <li asp-show="pageLinks.ShowApprenticeTrainingCourseCrumb" class="govuk-breadcrumbs__list-item">
+                    <li asp-show="@Model.ShowApprenticeTrainingCourseCrumb" class="govuk-breadcrumbs__list-item">
                         <a id="course-detail-breadcrumb"
                            class="govuk-breadcrumbs__link"
                            asp-route="@RouteNames.CourseDetails"
-                           asp-route-larsCode="@pageLinks.LarsCode"
-                           asp-route-location="@pageLinks.Location"
-                           asp-route-distance="@pageLinks.Distance">
+                           asp-route-larsCode="@Model.LarsCode"
+                           asp-route-location="@Model.Location"
+                           asp-route-distance="@Model.Distance">
                             Course details
                         </a>
                     </li>
 
-                    <li asp-show="pageLinks.ShowApprenticeTrainingCourseProvidersCrumb" class="govuk-breadcrumbs__list-item">
+                    <li asp-show="@Model.ShowApprenticeTrainingCourseProvidersCrumb" class="govuk-breadcrumbs__list-item">
                         <a id="providers-breadcrumb"
                            class="govuk-breadcrumbs__link"
                            asp-route="@RouteNames.CourseProviders"
-                           asp-route-larsCode="@pageLinks.LarsCode"
-                           asp-route-location="@pageLinks.Location"
-                           asp-route-distance="@pageLinks.Distance">
+                           asp-route-larsCode="@Model.LarsCode"
+                           asp-route-location="@Model.Location"
+                           asp-route-distance="@Model.Distance">
                             Training provider results
                         </a>
                     </li>

--- a/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
@@ -30,7 +30,7 @@
                         <a id="course-detail-breadcrumb"
                            class="govuk-breadcrumbs__link"
                            asp-route="@RouteNames.CourseDetails"
-                           asp-route-id="@pageLinks.CourseId"
+                           asp-route-larsCode="@pageLinks.LarsCode"
                            asp-route-location="@pageLinks.Location"
                            asp-route-distance="@pageLinks.Distance">
                             Course details
@@ -41,7 +41,7 @@
                         <a id="providers-breadcrumb"
                            class="govuk-breadcrumbs__link"
                            asp-route="@RouteNames.CourseProviders"
-                           asp-route-id="@pageLinks.CourseId"
+                           asp-route-larsCode="@pageLinks.LarsCode"
                            asp-route-location="@pageLinks.Location"
                            asp-route-distance="@pageLinks.Distance">
                             Training provider results

--- a/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Shared/_pageLinks.cshtml
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
     <partial name="_surveyLink" />
-    @if (Model is PageLinksViewModelBase pageLinks)
+    @if (Model is PageLinksViewModelBase)
     {
         <div class="govuk-grid-column-three-quarters">
             <div class="govuk-breadcrumbs">

--- a/src/SFA.DAS.FAT.Web/Views/Shortlist/Index.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Shortlist/Index.cshtml
@@ -63,7 +63,7 @@
 
                             <p class="govuk-body govuk-!-margin-bottom-6">
                                 <a asp-route="@RouteNames.CourseProviders" 
-                                    asp-route-id="@course.LarsCode" 
+                                    asp-route-larsCode="@course.LarsCode" 
                                     asp-route-location="@location.Description" 
                                     class="govuk-link govuk-link--no-visited-state">View other training providers for this course</a>
                             </p>

--- a/src/SFA.DAS.FAT.Web/Views/Shortlist/_ShortlistTable.cshtml
+++ b/src/SFA.DAS.FAT.Web/Views/Shortlist/_ShortlistTable.cshtml
@@ -23,7 +23,7 @@
             var routeData = new Dictionary<string, string>
             {
                 {"location", shortlistItem.LocationDescription ?? ""},
-                {"id",shortlistItem.LarsCode.ToString()},
+                {"larsCode",shortlistItem.LarsCode.ToString()},
                 {"providerId",shortlistItem.Ukprn.ToString()}
             };
 


### PR DESCRIPTION

This pull request standardizes the usage of the property name `LarsCode` instead of `Id` or `CourseId` throughout the application, particularly in the context of course provider queries, parameters, API requests, and related unit tests. 